### PR TITLE
Switch to maktaba dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,16 @@ Vim runtime files for my own language,
 Using [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```viml
-Plug 'mattn/webapi-vim' " This is a dependency
+Plug 'google/vim-maktaba' " This is a dependency
 Plug 'nfischer/vim-rainbows'
 ```
 
 Using [vundle](https://github.com/VundleVim/Vundle.vim):
 
 ```viml
-Plugin 'mattn/webapi-vim' " This is a dependency
+Plugin 'google/vim-maktaba' " This is a dependency
 Plugin 'nfischer/vim-rainbows'
 ```
-
-Or, check out
-[vim-addon-manager](https://github.com/MarcWeber/vim-addon-manager), which
-should resolve the dependencies for you.
 
 ## How do I use it?
 


### PR DESCRIPTION
**Breaking change**

This switches to using maktaba for JSON parsing instead of webapi. This
also updates documentation and adds a warning on startup if the
dependency isn't met.

This also fixes a breaking change in the neovim jobstart() API.

Fixes #4